### PR TITLE
Support remote execution

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,3 +3,11 @@
 # Build using platforms by default
 build --incompatible_enable_cc_toolchain_resolution
 build --platforms=@arm_none_eabi//platforms:arm_none_generic
+
+# Remote builds
+build:remote --genrule_strategy=remote
+build:remote --remote_download_minimal
+build:remote --remote_executor=grpc://localhost:8980
+
+# Linux host (used for remote builds)
+build:linux --extra_execution_platforms=//platforms/host:linux

--- a/.github/workflows/remote.yml
+++ b/.github/workflows/remote.yml
@@ -1,0 +1,16 @@
+name: Remote
+
+on: [push]
+
+jobs:
+
+  linux:
+    name: Bazel Remote Execution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: remote execution
+        run: |
+          git clone https://github.com/bazelbuild/bazel-buildfarm
+          cd bazel-buildfarm && ./examples/bf-run start && cd ..
+          bazelisk build --config=remote --config=linux examples:all

--- a/.github/workflows/remote.yml
+++ b/.github/workflows/remote.yml
@@ -1,6 +1,10 @@
 name: Remote
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
 

--- a/platforms/host/BUILD
+++ b/platforms/host/BUILD
@@ -1,0 +1,7 @@
+platform(
+    name = "linux",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)

--- a/toolchain/compiler.BUILD
+++ b/toolchain/compiler.BUILD
@@ -106,7 +106,6 @@ filegroup(
     srcs = [
         ":ar",
         ":as",
-        ":compiler_pieces",
         ":cpp",
         ":gcc",
         ":gcov",

--- a/toolchain/compiler.BUILD
+++ b/toolchain/compiler.BUILD
@@ -106,6 +106,7 @@ filegroup(
     srcs = [
         ":ar",
         ":as",
+        ":compiler_pieces",
         ":cpp",
         ":gcc",
         ":gcov",

--- a/toolchain/config.bzl
+++ b/toolchain/config.bzl
@@ -105,6 +105,7 @@ def _impl(ctx):
                 ],
                 flag_groups = [
                     flag_group(flags = include_flags + ctx.attr.copts),
+                    flag_group(flags = ["-no-canonical-prefixes"]),
                 ],
             ),
         ],


### PR DESCRIPTION
Add CI job for testing BRE support, and applies the fixes from [this PR](https://github.com/hexdae/rules_riscv_gcc/pull/6) to make BRE work for this toolchain.