### PR TITLE
Add support to include std includes

### DIFF
--- a/toolchain/config.bzl
+++ b/toolchain/config.bzl
@@ -29,6 +29,15 @@ def _impl(ctx):
     # Action -> binary mappings from Pigweed:
     # https://github.com/google/pigweed/blob/aac7fab/pw_toolchain_bazel/cc_toolchain/private/cc_toolchain.bzl#L19
 
+    default_compiler_flags = [
+        "-fno-canonical-system-headers",
+        "-no-canonical-prefixes",
+    ]
+    if not ctx.attr.include_std:
+        default_compiler_flags.append("-nostdinc")
+        if ctx.attr.gcc_tool == "g++":
+            default_compiler_flags.append("-nostdinc++")
+
     action_configs += _action_configs(
         ctx,
         [
@@ -83,11 +92,7 @@ def _impl(ctx):
                 ],
                 flag_groups = [
                     flag_group(flags = ["-I" + include.path for include in ctx.files.include_path]),
-                    flag_group(flags = ctx.attr.copts + [
-                        "-fno-canonical-system-headers",
-                        "-no-canonical-prefixes",
-                        "-nostdinc",
-                    ]),
+                    flag_group(flags = ctx.attr.copts + default_compiler_flags),
                 ],
             ),
         ],
@@ -150,6 +155,7 @@ cc_arm_none_eabi_config = rule(
         "linkopts": attr.string_list(default = []),
         "include_path": attr.label_list(default = [], allow_files = True),
         "library_path": attr.label_list(default = [], allow_files = True),
+        "include_std": attr.bool(default = False),
     },
     provides = [CcToolchainConfigInfo],
 )

--- a/toolchain/toolchain.bzl
+++ b/toolchain/toolchain.bzl
@@ -37,7 +37,7 @@ hosts = {
     "windows_x86_64": ["@platforms//os:windows", "@platforms//cpu:x86_64"],
 }
 
-def arm_none_eabi_toolchain(name, gcc_tool = "gcc", target_compatible_with = [], copts = [], linkopts = [], version = "9.2.1"):
+def arm_none_eabi_toolchain(name, gcc_tool = "gcc", target_compatible_with = [], copts = [], linkopts = [], version = "9.2.1", include_std = False):
     """
     Create an arm-none-eabi toolchain with the given configuration.
 
@@ -48,6 +48,7 @@ def arm_none_eabi_toolchain(name, gcc_tool = "gcc", target_compatible_with = [],
         copts: A list of compiler options to apply to the toolchain.
         linkopts: A list of linker options to apply to the toolchain.
         version: The version of the gcc toolchain.
+        include_std: Whether to include the standard library in the include path.
     """
 
     for host, exec_compatible_with in hosts.items():
@@ -72,6 +73,7 @@ def arm_none_eabi_toolchain(name, gcc_tool = "gcc", target_compatible_with = [],
             ],
             copts = copts,
             linkopts = linkopts,
+            include_std = include_std,
         )
 
         native.cc_toolchain(


### PR DESCRIPTION
Follow on for #29

Add support for making std includes available with a flag passed down from the top-level `arm_none_eabi_toolchain` macro.

Also adds `-nostdinc++` when using `g++`, which was missing.

Tested on a repo using the macro.
