### PR TITLE
Adds aarch64_none_linux_gnu support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
       USE_BAZEL_VERSION: "7.x"
     steps:
       - uses: actions/checkout@v2
+      - name: tests
+        run: bazel test //test:all
       - name: workspace
         working-directory: examples/workspace
         run: bazel test //:all
@@ -51,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: BUILD
-        run: bazel --output_user_root=C:/bzl build //...
+        run: bazel --output_user_root=C:/bzl test //test:all
 
   remote-execution:
     name: Bazel Remote Execution

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -31,9 +31,14 @@ arm_toolchain.aarch64_none_elf()
 
 use_repo(arm_toolchain, "aarch64_none_elf")
 
+arm_toolchain.aarch64_none_linux_gnu()
+
+use_repo(arm_toolchain, "aarch64_none_linux_gnu")
+
 register_toolchains(
     "//test/toolchains:all",
     "@aarch64_none_elf//toolchain:all",
+    "@aarch64_none_linux_gnu//toolchain:all",
     "@arm_none_eabi//toolchain:all",
     "@arm_none_linux_gnueabihf//toolchain:all",
     dev_dependency = True,

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,37 +2,29 @@
 
 module(
     name = "toolchains_arm_gnu",
-    compatibility_level = 1,
     version = "1.0.0",
+    compatibility_level = 1,
 )
 
 bazel_dep(name = "platforms", version = "0.0.8")
 bazel_dep(name = "rules_cc", version = "0.0.9")
 
 # DEV ONLY (not needed for release)
-bazel_dep(name = "aspect_bazel_lib", dev_dependency = True, version = "2.0.0")
-bazel_dep(name = "bazel_skylib", dev_dependency = True, version = "1.5.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.0.0", dev_dependency = True)
+bazel_dep(name = "bazel_skylib", version = "1.5.0", dev_dependency = True)
 
 arm_toolchain = use_extension(
     "@toolchains_arm_gnu//:extensions.bzl",
     "arm_toolchain",
     dev_dependency = True,
 )
-
 arm_toolchain.arm_none_eabi()
-
 use_repo(arm_toolchain, "arm_none_eabi")
-
 arm_toolchain.arm_none_linux_gnueabihf()
-
 use_repo(arm_toolchain, "arm_none_linux_gnueabihf")
-
 arm_toolchain.aarch64_none_elf()
-
 use_repo(arm_toolchain, "aarch64_none_elf")
-
 arm_toolchain.aarch64_none_linux_gnu()
-
 use_repo(arm_toolchain, "aarch64_none_linux_gnu")
 
 register_toolchains(

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "4a8c797fe907d0f4181bbea223642253c28a0bf9dd75b92ba07eaac54060ec17",
+  "moduleFileHash": "0aba0044f094fe48fa572f3496bb8259e324679de836666d558bf58f7bd2ce8c",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -25,6 +25,7 @@
       "toolchainsToRegister": [
         "//test/toolchains:all",
         "@aarch64_none_elf//toolchain:all",
+        "@aarch64_none_linux_gnu//toolchain:all",
         "@arm_none_eabi//toolchain:all",
         "@arm_none_linux_gnueabihf//toolchain:all"
       ],
@@ -41,12 +42,14 @@
           "imports": {
             "arm_none_eabi": "arm_none_eabi",
             "arm_none_linux_gnueabihf": "arm_none_linux_gnueabihf",
-            "aarch64_none_elf": "aarch64_none_elf"
+            "aarch64_none_elf": "aarch64_none_elf",
+            "aarch64_none_linux_gnu": "aarch64_none_linux_gnu"
           },
           "devImports": [
             "arm_none_eabi",
             "arm_none_linux_gnueabihf",
-            "aarch64_none_elf"
+            "aarch64_none_elf",
+            "aarch64_none_linux_gnu"
           ],
           "tags": [
             {
@@ -77,6 +80,16 @@
                 "file": "@@//:MODULE.bazel",
                 "line": 30,
                 "column": 31
+              }
+            },
+            {
+              "tagName": "aarch64_none_linux_gnu",
+              "attributeValues": {},
+              "devDependency": true,
+              "location": {
+                "file": "@@//:MODULE.bazel",
+                "line": 34,
+                "column": 37
               }
             }
           ],
@@ -856,7 +869,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%arm_toolchain": {
       "general": {
-        "bzlTransitiveDigest": "ADefdyKBxtMPa3FgB17+eZw31Y9l/FUd8YVRxOOqgr8=",
+        "bzlTransitiveDigest": "3FLQvbbwHCY3+2SJfn8bf0iLlPvqSsI//FzKTzYdWOg=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {
@@ -959,6 +972,25 @@
               ]
             }
           },
+          "aarch64_none_linux_gnu_linux_x86_64": {
+            "bzlFile": "@@//:deps.bzl",
+            "ruleClassName": "arm_gnu_cross_hosted_platform_specific_repo",
+            "attributes": {
+              "toolchain_prefix": "aarch64-none-linux-gnu",
+              "version": "13.2.1",
+              "name": "_main~arm_toolchain~aarch64_none_linux_gnu_linux_x86_64",
+              "sha256": "12fcdf13a7430655229b20438a49e8566e26551ba08759922cdaf4695b0d4e23",
+              "strip_prefix": "arm-gnu-toolchain-13.2.Rel1-x86_64-aarch64-none-linux-gnu",
+              "url": "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-aarch64-none-linux-gnu.tar.xz?rev=22c39fc25e5541818967b4ff5a09ef3e&hash=B9FEDC2947EB21151985C2DC534ECCEC",
+              "patches": [
+                "@@//toolchain:patches/0001-Resolve-libc-relative-to-sysroot-aarch64_none_linux_gnu.patch"
+              ],
+              "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:x86_64"
+              ]
+            }
+          },
           "aarch64_none_elf_linux_aarch64": {
             "bzlFile": "@@//:deps.bzl",
             "ruleClassName": "arm_gnu_cross_hosted_platform_specific_repo",
@@ -972,6 +1004,25 @@
               "exec_compatible_with": [
                 "@platforms//os:linux",
                 "@platforms//cpu:arm64"
+              ]
+            }
+          },
+          "aarch64_none_linux_gnu_windows_x86_64": {
+            "bzlFile": "@@//:deps.bzl",
+            "ruleClassName": "arm_gnu_cross_hosted_platform_specific_repo",
+            "attributes": {
+              "toolchain_prefix": "aarch64-none-linux-gnu",
+              "version": "13.2.1",
+              "name": "_main~arm_toolchain~aarch64_none_linux_gnu_windows_x86_64",
+              "sha256": "ccca7e520adbc5deb36d53a2b373e28a0c7e21107c487d4f5fd9cc8e0dbf6a11",
+              "strip_prefix": "arm-gnu-toolchain-13.2.Rel1-mingw-w64-i686-aarch64-none-linux-gnu",
+              "url": "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-aarch64-none-linux-gnu.zip?rev=861fed530201460f8f58b10dca7bd431&hash=A040842727683903E8646B42A96A8B98",
+              "patches": [
+                "@@//toolchain:patches/0001-Resolve-libc-relative-to-sysroot-aarch64_none_linux_gnu.patch"
+              ],
+              "exec_compatible_with": [
+                "@platforms//os:windows",
+                "@platforms//cpu:x86_64"
               ]
             }
           },
@@ -1091,6 +1142,26 @@
                 "@platforms//os:macos",
                 "@platforms//cpu:x86_64"
               ]
+            }
+          },
+          "aarch64_none_linux_gnu": {
+            "bzlFile": "@@//:deps.bzl",
+            "ruleClassName": "toolchains_arm_gnu_repo",
+            "attributes": {
+              "name": "_main~arm_toolchain~aarch64_none_linux_gnu",
+              "toolchain_name": "aarch64_none_linux_gnu",
+              "toolchain_prefix": "aarch64-none-linux-gnu",
+              "version": "13.2.1",
+              "hosts": {
+                "aarch64_none_linux_gnu_linux_x86_64": [
+                  "@platforms//os:linux",
+                  "@platforms//cpu:x86_64"
+                ],
+                "aarch64_none_linux_gnu_windows_x86_64": [
+                  "@platforms//os:windows",
+                  "@platforms//cpu:x86_64"
+                ]
+              }
             }
           },
           "arm_none_eabi": {

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "0aba0044f094fe48fa572f3496bb8259e324679de836666d558bf58f7bd2ce8c",
+  "moduleFileHash": "50804b6b325150c2e40e5294c534f39d2b773ffd9f789de82e7fdfd6fd60e184",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -58,7 +58,7 @@
               "devDependency": true,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 22,
+                "line": 21,
                 "column": 28
               }
             },
@@ -68,7 +68,7 @@
               "devDependency": true,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 26,
+                "line": 23,
                 "column": 39
               }
             },
@@ -78,7 +78,7 @@
               "devDependency": true,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 30,
+                "line": 25,
                 "column": 31
               }
             },
@@ -88,7 +88,7 @@
               "devDependency": true,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 34,
+                "line": 27,
                 "column": 37
               }
             }

--- a/deps.bzl
+++ b/deps.bzl
@@ -1,9 +1,10 @@
 """deps.bzl"""
 
+load("@toolchains_arm_gnu//toolchain:toolchain.bzl", "tools")
+load("@toolchains_arm_gnu//toolchain/archives:aarch64_none_elf.bzl", "AARCH64_NONE_ELF")
+load("@toolchains_arm_gnu//toolchain/archives:aarch64_none_linux_gnu.bzl", "AARCH64_NONE_LINUX_GNU")
 load("@toolchains_arm_gnu//toolchain/archives:arm_none_eabi.bzl", "ARM_NONE_EABI")
 load("@toolchains_arm_gnu//toolchain/archives:arm_none_linux_gnueabihf.bzl", "ARM_NONE_LINUX_GNUEABIHF")
-load("@toolchains_arm_gnu//toolchain/archives:aarch64_none_elf.bzl", "AARCH64_NONE_ELF")
-load("@toolchains_arm_gnu//toolchain:toolchain.bzl", "tools")
 
 def _arm_gnu_cross_hosted_platform_specific_repo_impl(repository_ctx):
     """Defines a host-specific repository for the ARM GNU toolchain."""
@@ -148,7 +149,7 @@ def arm_none_linux_gnueabihf_deps(version = "13.2.1", archives = ARM_NONE_LINUX_
     )
 
 def aarch64_none_elf_deps(version = "13.2.1-1.1", archives = AARCH64_NONE_ELF):
-    """Workspace dependencies for the arm linux gcc toolchain
+    """Workspace dependencies for the arm gcc toolchain
 
     Args:
         version: The version of the toolchain to use. If None, the latest version is used.
@@ -157,6 +158,20 @@ def aarch64_none_elf_deps(version = "13.2.1-1.1", archives = AARCH64_NONE_ELF):
     toolchains_arm_gnu_deps(
         "aarch64_none_elf",
         "aarch64-none-elf",
+        version,
+        archives,
+    )
+
+def aarch64_none_linux_gnu_deps(version = "13.2.1", archives = AARCH64_NONE_LINUX_GNU):
+    """Workspace dependencies for the arm linux gcc toolchain
+
+    Args:
+        version: The version of the toolchain to use. If None, the latest version is used.
+        archives: A dictionary of the version to archive attributes.
+    """
+    toolchains_arm_gnu_deps(
+        "aarch64_none_linux_gnu",
+        "aarch64-none-linux-gnu",
         version,
         archives,
     )

--- a/extensions.bzl
+++ b/extensions.bzl
@@ -1,13 +1,24 @@
 """Module extension for toolchains"""
 
-load("@toolchains_arm_gnu//toolchain/archives:arm_none_eabi.bzl", "ARM_NONE_EABI")
-load("@toolchains_arm_gnu//toolchain/archives:arm_none_linux_gnueabihf.bzl", "ARM_NONE_LINUX_GNUEABIHF")
-load("@toolchains_arm_gnu//toolchain/archives:aarch64_none_elf.bzl", "AARCH64_NONE_ELF")
 load(
     "@toolchains_arm_gnu//:deps.bzl",
     "aarch64_none_elf_deps",
+    "aarch64_none_linux_gnu_deps",
     "arm_none_eabi_deps",
     "arm_none_linux_gnueabihf_deps",
+)
+load("@toolchains_arm_gnu//toolchain/archives:aarch64_none_elf.bzl", "AARCH64_NONE_ELF")
+load(
+    "@toolchains_arm_gnu//toolchain/archives:aarch64_none_linux_gnu.bzl",
+    "AARCH64_NONE_LINUX_GNU",
+)
+load(
+    "@toolchains_arm_gnu//toolchain/archives:arm_none_eabi.bzl",
+    "ARM_NONE_EABI",
+)
+load(
+    "@toolchains_arm_gnu//toolchain/archives:arm_none_linux_gnueabihf.bzl",
+    "ARM_NONE_LINUX_GNUEABIHF",
 )
 
 def _semver(version):
@@ -75,6 +86,10 @@ def _arm_toolchain_impl(ctx):
             tag = lambda mod: mod.tags.aarch64_none_elf,
             deps = aarch64_none_elf_deps,
         ),
+        _module_toolchain(
+            tag = lambda mod: mod.tags.aarch64_none_linux_gnu,
+            deps = aarch64_none_linux_gnu_deps,
+        ),
     ]
 
     for toolchain in available_toolchains:
@@ -94,6 +109,9 @@ arm_toolchain = module_extension(
         }),
         "aarch64_none_elf": tag_class(attrs = {
             "version": attr.string(default = _max_version(AARCH64_NONE_ELF.keys())),
+        }),
+        "aarch64_none_linux_gnu": tag_class(attrs = {
+            "version": attr.string(default = _max_version(AARCH64_NONE_LINUX_GNU.keys())),
         }),
     },
 )

--- a/test/BUILD
+++ b/test/BUILD
@@ -6,6 +6,11 @@ build_test(
 )
 
 build_test(
+    name = "aarch64_none_linux_gnu",
+    targets = ["//test/aarch64-none-linux-gnu:hex"],
+)
+
+build_test(
     name = "arm_none_eabi",
     targets = ["//test/arm-none-eabi:hex"],
 )

--- a/test/aarch64-none-linux-gnu/BUILD
+++ b/test/aarch64-none-linux-gnu/BUILD
@@ -41,12 +41,12 @@ cc_binary(
 platform_transition_filegroup(
     name = "elf",
     srcs = [":arm_elf"],
-    target_platform = ":aarch64_none_linux_gnu",
     target_compatible_with = select({
-        "@platforms//os:linux": ["@platforms//cpu:x86_64"], # linux x86 (no arm)
-        "@platforms//os:windows": ["@platforms//cpu:x86_64"], # windows
-        "//conditions:default": ["@platforms//:incompatible"]
-    })
+        "@platforms//os:linux": ["@platforms//cpu:x86_64"],  # linux x86 (no arm)
+        "@platforms//os:windows": ["@platforms//cpu:x86_64"],  # windows
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    target_platform = ":aarch64_none_linux_gnu",
 )
 
 genrule(

--- a/test/aarch64-none-linux-gnu/BUILD
+++ b/test/aarch64-none-linux-gnu/BUILD
@@ -4,9 +4,9 @@ load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 
 platform(
-    name = "arm_linux_gnueabihf",
+    name = "aarch64_none_linux_gnu",
     constraint_values = [
-        "@platforms//cpu:arm",
+        "@platforms//cpu:aarch64",
         "@platforms//os:linux",
     ],
 )
@@ -16,12 +16,11 @@ cc_library(
     srcs = ["library.cpp"],
     hdrs = ["library.h"],
     copts = [
-        "-mcpu=cortex-a5",
-        "-mthumb",
+        "-mcpu=cortex-a53",
     ],
     includes = ["includes"],
     target_compatible_with = [
-        "@platforms//cpu:arm",
+        "@platforms//cpu:aarch64",
         "@platforms//os:linux",
     ],
 )
@@ -30,8 +29,11 @@ cc_binary(
     name = "arm_elf",
     srcs = ["main.cpp"],
     copts = [
-        "-mcpu=cortex-a5",
-        "-mthumb",
+        "-mcpu=cortex-a53",
+    ],
+    linkopts = [
+        "-nostartfiles",
+        "-Wl,--entry,main",
     ],
     deps = [":arm_library"],
 )
@@ -39,18 +41,19 @@ cc_binary(
 platform_transition_filegroup(
     name = "elf",
     srcs = [":arm_elf"],
+    target_platform = ":aarch64_none_linux_gnu",
     target_compatible_with = select({
-        "@platforms//os:macos": ["@platforms//:incompatible"],  # no compiler on macos (yet)
-        "//conditions:default": [],
-    }),
-    target_platform = ":arm_linux_gnueabihf",
+        "@platforms//os:linux": ["@platforms//cpu:x86_64"], # linux x86 (no arm)
+        "@platforms//os:windows": ["@platforms//cpu:x86_64"], # windows
+        "//conditions:default": ["@platforms//:incompatible"]
+    })
 )
 
 genrule(
     name = "hex",
     srcs = [":elf"],
     outs = ["mock.hex"],
-    cmd = "$(execpath @arm_none_linux_gnueabihf//:objcopy) -O ihex $< $@",
-    tools = ["@arm_none_linux_gnueabihf//:objcopy"],
+    cmd = "$(execpath @aarch64_none_linux_gnu//:objcopy) -O ihex $< $@",
+    tools = ["@aarch64_none_linux_gnu//:objcopy"],
     visibility = ["//visibility:public"],
 )

--- a/test/aarch64-none-linux-gnu/library.cpp
+++ b/test/aarch64-none-linux-gnu/library.cpp
@@ -1,0 +1,15 @@
+#include "library.h"
+#include <vector>
+
+uint16_t baz(uint8_t a) { return a * 2; }
+
+uint32_t foo() {
+    static constexpr int k = 5;
+    return baz(k);
+}
+
+uint16_t foobaz() {
+    std::vector<uint8_t> vec(10);
+    vec.push_back(1);
+    return vec[0];
+}

--- a/test/aarch64-none-linux-gnu/library.h
+++ b/test/aarch64-none-linux-gnu/library.h
@@ -1,0 +1,5 @@
+#include <stdint.h>
+
+uint16_t baz(uint8_t var);
+uint32_t foo(void);
+uint16_t foobaz();

--- a/test/aarch64-none-linux-gnu/main.cpp
+++ b/test/aarch64-none-linux-gnu/main.cpp
@@ -1,0 +1,5 @@
+// The simplest possible main function
+
+int main(){
+    return 0;
+}

--- a/toolchain/archives/aarch64_none_linux_gnu.bzl
+++ b/toolchain/archives/aarch64_none_linux_gnu.bzl
@@ -1,0 +1,28 @@
+"""aarch64-none-linux-gnu toolchiain archives"""
+
+AARCH64_NONE_LINUX_GNU = {
+    "13.2.1": [
+        {
+            "name": "aarch64_none_linux_gnu_linux_x86_64",
+            "sha256": "12fcdf13a7430655229b20438a49e8566e26551ba08759922cdaf4695b0d4e23",
+            "strip_prefix": "arm-gnu-toolchain-13.2.Rel1-x86_64-aarch64-none-linux-gnu",
+            "url": "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-aarch64-none-linux-gnu.tar.xz?rev=22c39fc25e5541818967b4ff5a09ef3e&hash=B9FEDC2947EB21151985C2DC534ECCEC",
+            "patches": ["@toolchains_arm_gnu//toolchain:patches/0001-Resolve-libc-relative-to-sysroot-aarch64_none_linux_gnu.patch"],
+            "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:x86_64",
+            ],
+        },
+        {
+            "name": "aarch64_none_linux_gnu_windows_x86_64",
+            "sha256": "ccca7e520adbc5deb36d53a2b373e28a0c7e21107c487d4f5fd9cc8e0dbf6a11",
+            "strip_prefix": "arm-gnu-toolchain-13.2.Rel1-mingw-w64-i686-aarch64-none-linux-gnu",
+            "url": "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-aarch64-none-linux-gnu.zip?rev=861fed530201460f8f58b10dca7bd431&hash=A040842727683903E8646B42A96A8B98",
+            "patches": ["@toolchains_arm_gnu//toolchain:patches/0001-Resolve-libc-relative-to-sysroot-aarch64_none_linux_gnu.patch"],
+            "exec_compatible_with": [
+                "@platforms//os:windows",
+                "@platforms//cpu:x86_64",
+            ],
+        },
+    ],
+}

--- a/toolchain/patches/0001-Resolve-libc-relative-to-sysroot-aarch64_none_linux_gnu.patch
+++ b/toolchain/patches/0001-Resolve-libc-relative-to-sysroot-aarch64_none_linux_gnu.patch
@@ -1,0 +1,16 @@
+Resolve libc relative to sysroot
+
+In the arm linux toolchain, libc.so is simply a link script that
+points to the real libc.so shared library. However, the path of the
+actual shared object is specified as an absolute path, which means
+it is not resolved relative to the toolchain prefix or sysroot
+directories. Adding '=' here causes ld to search for these files
+relative to the library search directories.
+--- a/aarch64-none-linux-gnu/libc/usr/lib64/libc.so
++++ b/aarch64-none-linux-gnu/libc/usr/lib64/libc.so
+@@ -2,4 +2,4 @@
+    Use the shared library, but some functions are only in
+    the static library, so try that secondarily.  */
+ OUTPUT_FORMAT(elf64-littleaarch64)
+-GROUP ( /lib64/libc.so.6 /usr/lib64/libc_nonshared.a  AS_NEEDED ( /lib/ld-linux-aarch64.so.1 ) )
++GROUP ( =/lib64/libc.so.6 =/usr/lib64/libc_nonshared.a  AS_NEEDED ( =/lib/ld-linux-aarch64.so.1 ) )

--- a/toolchain/toolchain.bzl
+++ b/toolchain/toolchain.bzl
@@ -2,8 +2,8 @@
 This module provides functions to register an arm-none-eabi toolchain
 """
 
-load("@toolchains_arm_gnu//toolchain:config.bzl", "cc_arm_gnu_toolchain_config")
 load("@rules_cc//cc:defs.bzl", "cc_toolchain")
+load("@toolchains_arm_gnu//toolchain:config.bzl", "cc_arm_gnu_toolchain_config")
 
 tools = [
     "as",
@@ -38,6 +38,9 @@ target_constraints = {
     "aarch64-none-elf": {
         "arm": ["@platforms//os:none", "@platforms//cpu:aarch64"],
     },
+    "aarch64-none-linux-gnu": {
+        "aarch64": ["@platforms//os:linux", "@platforms//cpu:aarch64"],
+    },
 }
 
 hosts = {
@@ -59,6 +62,9 @@ hosts = {
         "darwin_arm64": ["@platforms//os:macos", "@platforms//cpu:arm64"],
         "linux_x86_64": ["@platforms//os:linux", "@platforms//cpu:x86_64"],
         "linux_aarch64": ["@platforms//os:linux", "@platforms//cpu:arm64"],
+    },
+    "aarch64-none-linux-gnu": {
+        "linux_x86_64": ["@platforms//os:linux", "@platforms//cpu:x86_64"],
         "windows_x86_64": ["@platforms//os:windows", "@platforms//cpu:x86_64"],
     },
 }
@@ -180,3 +186,32 @@ def aarch64_none_elf_toolchain(name, version, **kwargs):
         abi_version = "elf",
         **kwargs
     )
+
+def aarch64_none_linux_gnu_toolchain(
+        name,
+        version = "13.2.1",
+        linkopts = [],
+        **kwargs):
+    """
+    Create an aarch64-none-linux-gnu toolchain with the given configuration.
+
+    Args:
+        name: The name of the toolchain.
+        version: The version of the gcc toolchain.
+        linkopts: Additional linker options.
+        **kwargs: Additional keyword arguments.
+    """
+    _arm_gnu_toolchain(
+        name,
+        toolchain = "aarch64_none_linux_gnu",
+        toolchain_prefix = "aarch64-none-linux-gnu",
+        version = version,
+        abi_version = "gnu",
+        linkopts = ["-lc", "-lstdc++"] + linkopts,
+        include_std = True,
+        **kwargs
+    )
+
+def register_arm_gnu_toolchain(name, prefix):
+    for host in hosts[prefix]:
+        native.register_toolchains("{}_{}".format(name, host))

--- a/toolchain/toolchain.bzl
+++ b/toolchain/toolchain.bzl
@@ -211,7 +211,3 @@ def aarch64_none_linux_gnu_toolchain(
         include_std = True,
         **kwargs
     )
-
-def register_arm_gnu_toolchain(name, prefix):
-    for host in hosts[prefix]:
-        native.register_toolchains("{}_{}".format(name, host))

--- a/toolchain/toolchain.bzl
+++ b/toolchain/toolchain.bzl
@@ -62,6 +62,7 @@ hosts = {
         "darwin_arm64": ["@platforms//os:macos", "@platforms//cpu:arm64"],
         "linux_x86_64": ["@platforms//os:linux", "@platforms//cpu:x86_64"],
         "linux_aarch64": ["@platforms//os:linux", "@platforms//cpu:arm64"],
+        "windows_x86_64": ["@platforms//os:windows", "@platforms//cpu:x86_64"],
     },
     "aarch64-none-linux-gnu": {
         "linux_x86_64": ["@platforms//os:linux", "@platforms//cpu:x86_64"],


### PR DESCRIPTION
This is a straightforward adding aarch64_none_linux_gnu following the existing scheme.
There seems to be some unnecessary formatting rearrangements. Those are automatically done by the bazel style formatter embedded in my editor. I have good confidence in what it's doing.