### PR TITLE
handle transitive deps of `additional_link_libraries`

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -139,7 +139,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%arm_toolchain": {
       "general": {
-        "bzlTransitiveDigest": "u/MHEDqrY6t5zvDArzdCUgXwMLBgC0k67ZL2eV4eOtY=",
+        "bzlTransitiveDigest": "t3cHywM6dCabqw7xBNJN+O3csA16VA/X6g/5Yqx9Tqc=",
         "usagesDigest": "P/3UnhHe8mBjAHhQOgY8IbRzO7gyGHPkTqDB/W/U9qY=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/examples/bzlmod/custom/toolchain/BUILD
+++ b/examples/bzlmod/custom/toolchain/BUILD
@@ -46,12 +46,19 @@ arm_none_eabi_toolchain(
     ],
 )
 
+# this dummy is used to test that transitive deps are included
+cc_library(
+    name = "start_dep",
+    srcs = ["dummy.c"],
+)
+
 # always linked in with the toolchain below
 cc_library(
     name = "start",
     srcs = ["start.c"],
     additional_linker_inputs = ["link.ld"],
     linkopts = ["-T $(location :link.ld)"],
+    deps = [":start_dep"],
 )
 
 # Cortex-M4 toolchain that always links `:start`

--- a/examples/bzlmod/custom/toolchain/dummy.c
+++ b/examples/bzlmod/custom/toolchain/dummy.c
@@ -1,0 +1,1 @@
+void dummy() {}


### PR DESCRIPTION
When defining an `additional_link_library` that uses `deps`, e.g.

```starlark
cc_library(
    name = "start",
    srcs = ["start.c"],
    ...
    deps = [":registers"],
)
```

where the `start` library depends on a separate `registers` library,
libraries in `deps` are not compiled.

Similar to `additional_linker_inputs`, these files must be explicitly forwarded in
the `DefaultInfo` returned by the transition implementation function.