### PR TITLE
fix pure asm file (with `.s` extension) compilation

### DIFF
--- a/toolchain/templates/alias.BUILD
+++ b/toolchain/templates/alias.BUILD
@@ -18,6 +18,7 @@ TOOLS = %tools%
         "compiler_pieces",
         "compiler_files",
         "ar_files",
+        "as_files",
         "linker_files",
         "compiler_components",
     ]

--- a/toolchain/templates/compiler.BUILD
+++ b/toolchain/templates/compiler.BUILD
@@ -65,6 +65,11 @@ filegroup(
 )
 
 filegroup(
+    name = "as_files",
+    srcs = [":compiler_pieces"],
+)
+
+filegroup(
     name = "linker_files",
     srcs = [":compiler_pieces"],
 )

--- a/toolchain/templates/toolchain.bazel
+++ b/toolchain/templates/toolchain.bazel
@@ -190,6 +190,7 @@ def %toolchain_name%_toolchain(
                 name = "cc_toolchain_{}_{}".format(variant.name, host_repo),
                 all_files = "{}:compiler_pieces".format(alias_repo),
                 ar_files = "{}:ar_files".format(alias_repo),
+                as_files = "{}:as_files".format(alias_repo),
                 compiler_files = "{}:compiler_files".format(alias_repo),
                 dwp_files = ":empty",
                 linker_files = ":{}_{}_all_linker_files".format(variant.name, host_repo),

--- a/toolchain/toolchain.bzl
+++ b/toolchain/toolchain.bzl
@@ -109,6 +109,7 @@ def _arm_gnu_toolchain(
             name = "cc_toolchain_{}_{}".format(host, name),
             all_files = "@{}_{}//:compiler_pieces".format(toolchain, host),
             ar_files = "@{}_{}//:ar_files".format(toolchain, host),
+            as_files = "@{}_{}//:as_files".format(toolchain, host),
             compiler_files = "@{}_{}//:compiler_files".format(toolchain, host),
             dwp_files = ":empty",
             linker_files = "@{}_{}//:linker_files".format(toolchain, host),


### PR DESCRIPTION
fixes #78
 
4295ffc4f6286cd8eade3a56c6022878c0184ff8 shows that the issue can reproduced easily
a47360a9a6d2642da64e86d4fcd21d8ccfaa6fbc has the fix that gets the example to build successfully

After @hexdae takes an initial look, I can drop the first commit